### PR TITLE
修复恋爱墙倒计时获取本地时间时报错。

### DIFF
--- a/src/js/common.js
+++ b/src/js/common.js
@@ -390,7 +390,7 @@ const commonContext = {
     }
     const grt = new Date(loveTime)
     setInterval(function () {
-      let now = Date.now()
+      let now = new Date(Date.now())
       let difference = parseInt((now - grt) / 1000)
       let seconds = difference % 60
       difference = parseInt(difference / 60)


### PR DESCRIPTION
由于Date.now返回的是时间戳，无法直接getFullYear，导致恋爱墙倒计时无法正常显示并报错。