### PR TITLE
feat: 新增友链隐藏功能

### DIFF
--- a/annotation-setting.yaml
+++ b/annotation-setting.yaml
@@ -143,3 +143,43 @@ spec:
       name: "desc"
       label: "描述"
       placeholder: '请输入鼠标悬停时描述内容，默认为菜单名'
+
+---
+apiVersion: v1alpha1
+kind: AnnotationSetting
+metadata:
+  generateName: annotation-setting-
+spec:
+  targetRef:
+    group: core.halo.run
+    kind: LinkGroup
+  formSchema:
+    - $formkit: "select"
+      name: "hide"
+      label: "是否隐藏"
+      value: "false"
+      options:
+        - value: "true"
+          label: 是
+        - value: "false"
+          label: 否
+
+---
+apiVersion: v1alpha1
+kind: AnnotationSetting
+metadata:
+  generateName: annotation-setting-
+spec:
+  targetRef:
+    group: core.halo.run
+    kind: Link
+  formSchema:
+    - $formkit: "select"
+      name: "hide"
+      label: "是否隐藏"
+      value: "false"
+      options:
+        - value: "true"
+          label: 是
+        - value: "false"
+          label: 否

--- a/templates/links.html
+++ b/templates/links.html
@@ -10,11 +10,11 @@
             <div class="card-content main">
                 <h1 class="title" th:text="${#strings.defaultString(linksTitle, '友链')} + ' - ' + ${contributor.displayName} + '的小伙伴们'"></h1>
                 <div class="main-content">
-                    <th:block th:each="group : ${groups}">
+                    <th:block th:each="group : ${groups}" th:if="${#annotations.getOrDefault(group, 'hide','false') == 'false'}">
                         <div th:if="${!#lists.isEmpty(group.links)}" class="links">
                             <h3 class="link-title" th:text="${#strings.defaultString(group.spec.displayName, '小伙伴们')}" th:id="'toc' + ${groupStat.index}"></h3>
                             <ul class="link-items">
-                                <li th:each="link : ${group.links}">
+                                <li th:each="link : ${group.links}" th:if="${#annotations.getOrDefault(link, 'hide','false') == 'false'}">
                                     <a class="links-item" th:href="${link.spec.url}" rel="noopener noreferrer" target="_blank"
                                        th:title="${link.spec.description}">
                                         <img th:if="${#strings.isEmpty(link.spec.logo)}" class="not-gallery" th:title="${link.spec.displayName}" th:src="${defaultAvatar}" th:alt="${link.spec.displayName}">


### PR DESCRIPTION
支持隐藏**链接组**或隐藏**单链接**，隐藏**链接组**的优先级高于隐藏**单链接**，默认显示所有。

效果如下：

![image](https://github.com/user-attachments/assets/ba9f82e5-16f5-4b51-8fe3-3080b7f5fd38)
